### PR TITLE
feat: Auto-handle $/cancelRequest in route()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ while let Some(result) = conn.receiver.next().await {
         IncomingMessage::Notification(notif) if notif.method == "exit" => {
             break;
         }
+        IncomingMessage::CancelHandled => {}
         IncomingMessage::Notification(_) => {}
         IncomingMessage::ResponseRouted | IncomingMessage::ResponseUnknown(_) => {}
     }

--- a/examples/formatter_server.rs
+++ b/examples/formatter_server.rs
@@ -144,14 +144,10 @@ where
                     std::process::exit(exit_code as i32);
                 }
 
-                // Handle cancel requests
-                if conn.handle_cancel_request(&notif).is_some() {
-                    continue;
-                }
-
                 // Handle other notifications
                 handle_notification(&mut state, &notif);
             }
+            IncomingMessage::CancelHandled => {}
             IncomingMessage::ResponseRouted => {
                 // Response was delivered to awaiting receiver
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -436,6 +436,7 @@ where
     ///
     /// - [`IncomingMessage::Request`](crate::IncomingMessage::Request) - Handle the request and send a response
     /// - [`IncomingMessage::Notification`](crate::IncomingMessage::Notification) - Handle the notification
+    /// - [`IncomingMessage::CancelHandled`](crate::IncomingMessage::CancelHandled) - `$/cancelRequest` was applied automatically
     /// - [`IncomingMessage::ResponseRouted`](crate::IncomingMessage::ResponseRouted) - Response was delivered to awaiting receiver
     /// - [`IncomingMessage::ResponseUnknown`](crate::IncomingMessage::ResponseUnknown) - No pending request for this response ID
     ///
@@ -461,6 +462,9 @@ where
     ///             // Handle notification
     ///             println!("Notification: {}", notif.method);
     ///         }
+    ///         IncomingMessage::CancelHandled => {
+    ///             // `$/cancelRequest` was handled by route()
+    ///         }
     ///         IncomingMessage::ResponseRouted => {
     ///             // Response delivered to awaiting task
     ///         }
@@ -481,7 +485,16 @@ where
                     .register(req.id.clone(), I::default(), token.clone());
                 crate::IncomingMessage::Request(req, token)
             }
-            Message::Notification(notif) => crate::IncomingMessage::Notification(notif),
+            Message::Notification(notif) => {
+                if notif.method == crate::request_queue::CANCEL_REQUEST_METHOD {
+                    if let Some(id) = crate::parse_cancel_params(&notif.params) {
+                        self.request_queue.incoming.cancel(&id);
+                    }
+                    crate::IncomingMessage::CancelHandled
+                } else {
+                    crate::IncomingMessage::Notification(notif)
+                }
+            }
             Message::Response(resp) => {
                 if let Some(id) = resp.id.clone() {
                     if self
@@ -512,7 +525,8 @@ where
     /// Cancels an incoming request by request ID.
     ///
     /// This is a convenience method that cancels the [`CancellationToken`] for a registered
-    /// incoming request. Use this when you receive a `$/cancelRequest` notification.
+    /// incoming request. Use this for manual cancellation flows outside of
+    /// [`route()`](Self::route), which already auto-handles `$/cancelRequest` notifications.
     ///
     /// # Arguments
     ///
@@ -587,6 +601,9 @@ where
     /// and cancels the corresponding request's token. If the request is not pending
     /// (already completed or never registered), this is a no-op.
     ///
+    /// Deprecated: [`route()`](Self::route) now performs this automatically for
+    /// routed notifications.
+    ///
     /// # Arguments
     ///
     /// * `notification` - The notification to check
@@ -620,6 +637,7 @@ where
     /// assert_eq!(result, Some(true));
     /// # });
     /// ```
+    #[deprecated(note = "route() now handles $/cancelRequest automatically")]
     pub fn handle_cancel_request(&mut self, notification: &crate::Notification) -> Option<bool> {
         use crate::request_queue::{parse_cancel_params, CANCEL_REQUEST_METHOD};
 
@@ -1791,6 +1809,56 @@ mod tests {
         }
     }
 
+    #[test]
+    fn route_cancel_request_returns_cancel_handled_and_cancels_pending() {
+        let (stream, _) = tokio::io::duplex(4096);
+        let mut conn: Connection<_, ()> = Connection::new(stream);
+
+        let request = Request::new(42, "test", None);
+        let routed = conn.route(Message::Request(request));
+        let IncomingMessage::Request(_, token) = routed else {
+            panic!("Expected IncomingMessage::Request")
+        };
+        assert!(!token.is_cancelled());
+
+        let cancel = Message::Notification(Notification::new(
+            "$/cancelRequest",
+            Some(json!({"id": 42})),
+        ));
+
+        let result = conn.route(cancel);
+        assert!(matches!(result, IncomingMessage::CancelHandled));
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn route_cancel_request_unknown_id_returns_cancel_handled() {
+        let (stream, _) = tokio::io::duplex(4096);
+        let mut conn: Connection<_, ()> = Connection::new(stream);
+
+        let cancel = Message::Notification(Notification::new(
+            "$/cancelRequest",
+            Some(json!({"id": 999})),
+        ));
+
+        let result = conn.route(cancel);
+        assert!(matches!(result, IncomingMessage::CancelHandled));
+    }
+
+    #[test]
+    fn route_cancel_request_malformed_params_returns_cancel_handled() {
+        let (stream, _) = tokio::io::duplex(4096);
+        let mut conn: Connection<_, ()> = Connection::new(stream);
+
+        let cancel = Message::Notification(Notification::new(
+            "$/cancelRequest",
+            Some(json!({"other": "field"})),
+        ));
+
+        let result = conn.route(cancel);
+        assert!(matches!(result, IncomingMessage::CancelHandled));
+    }
+
     #[tokio::test]
     async fn route_response_to_pending_outgoing_request() {
         let (stream, _) = tokio::io::duplex(4096);
@@ -1937,6 +2005,7 @@ mod tests {
     // =========================================================================
 
     #[test]
+    #[allow(deprecated)]
     fn handle_cancel_request_cancels_pending() {
         let (stream, _) = tokio::io::duplex(4096);
         let mut conn: Connection<_, ()> = Connection::new(stream);
@@ -1961,6 +2030,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn handle_cancel_request_unknown_id_returns_false() {
         let (stream, _) = tokio::io::duplex(4096);
         let mut conn: Connection<_, String> = Connection::new(stream);
@@ -1972,6 +2042,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn handle_cancel_request_wrong_method_returns_none() {
         let (stream, _) = tokio::io::duplex(4096);
         let mut conn: Connection<_, String> = Connection::new(stream);
@@ -1986,6 +2057,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn handle_cancel_request_malformed_params_returns_none() {
         let (stream, _) = tokio::io::duplex(4096);
         let mut conn: Connection<_, String> = Connection::new(stream);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 //! The [`IncomingMessage`] enum classifies messages received from [`Connection::route()`]:
 //! - [`IncomingMessage::Request`] - A request with automatic [`CancellationToken`] for cooperative cancellation
 //! - [`IncomingMessage::Notification`] - A notification (no response expected)
+//! - [`IncomingMessage::CancelHandled`] - A `$/cancelRequest` notification already applied by `route()`
 //! - [`IncomingMessage::ResponseRouted`] - A response delivered to an awaiting receiver
 //! - [`IncomingMessage::ResponseUnknown`] - A response for an unknown request ID
 

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -9,7 +9,8 @@
 //!
 //! 1. **Message Classification**: The [`IncomingMessage`] enum categorizes received
 //!    messages into requests that need responses, notifications that are fire-and-forget,
-//!    or responses that were either routed to pending requests or are unknown.
+//!    automatically handled cancellation notifications, or responses that were either
+//!    routed to pending requests or are unknown.
 //!
 //! 2. **Response Routing**: When the server sends requests to the client, responses
 //!    are automatically routed to the waiting receivers via oneshot channels.
@@ -25,6 +26,9 @@
 //!
 //! let notif = Message::Notification(Notification::new("initialized", None));
 //! // After calling route(), you get IncomingMessage::Notification(notif)
+//!
+//! let cancel = Message::Notification(Notification::new("$/cancelRequest", None));
+//! // After calling route(), you get IncomingMessage::CancelHandled
 //! ```
 
 use tokio_util::sync::CancellationToken;
@@ -43,6 +47,8 @@ use crate::message::{Notification, Request, Response};
 ///   a [`CancellationToken`] that is triggered on `$/cancelRequest` or shutdown.
 /// - [`Notification`](IncomingMessage::Notification): A fire-and-forget notification.
 ///   No response is expected.
+/// - [`CancelHandled`](IncomingMessage::CancelHandled): A `$/cancelRequest`
+///   notification that was automatically processed by [`Connection::route()`](crate::Connection::route).
 /// - [`ResponseRouted`](IncomingMessage::ResponseRouted): A response that was successfully
 ///   delivered to a pending outgoing request's receiver.
 /// - [`ResponseUnknown`](IncomingMessage::ResponseUnknown): A response for which no pending
@@ -62,6 +68,9 @@ use crate::message::{Notification, Request, Response};
 ///         }
 ///         IncomingMessage::Notification(notif) => {
 ///             println!("Handle notification: {}", notif.method);
+///         }
+///         IncomingMessage::CancelHandled => {
+///             // `$/cancelRequest` was applied automatically
 ///         }
 ///         IncomingMessage::ResponseRouted => {
 ///             // Response was delivered to awaiting task, nothing to do
@@ -89,6 +98,9 @@ pub enum IncomingMessage {
     ///
     /// No response is expected or allowed.
     Notification(Notification),
+
+    /// A `$/cancelRequest` notification that was automatically processed.
+    CancelHandled,
 
     /// A response that was successfully delivered to a pending outgoing request.
     ///
@@ -233,6 +245,7 @@ mod tests {
 
         let _req = IncomingMessage::Request(request, token);
         let _notif = IncomingMessage::Notification(notification);
+        let _cancelled = IncomingMessage::CancelHandled;
         let _routed = IncomingMessage::ResponseRouted;
         let _unknown = IncomingMessage::ResponseUnknown(response);
     }
@@ -246,6 +259,9 @@ mod tests {
         let incoming = IncomingMessage::Request(request, token);
         let debug_str = format!("{incoming:?}");
         assert!(debug_str.contains("Request"));
+
+        let cancel_debug = format!("{:?}", IncomingMessage::CancelHandled);
+        assert!(cancel_debug.contains("CancelHandled"));
     }
 
     // ============== cancelled_response Tests ==============


### PR DESCRIPTION
## Summary

Automatically handle `$/cancelRequest` notifications inside `Connection::route()`, so servers get cancellation support without manual dispatch boilerplate.

## Changes

- `route()` now intercepts `$/cancelRequest` notifications and cancels the corresponding pending request
- Added cancellation tracking to `Connection`
- Updated example server to remove manual cancel handling (it's now automatic)
- Added tests for auto-cancel behavior

## Breaking Changes

None — this is additive. Servers that previously handled `$/cancelRequest` manually will see it handled before reaching their dispatch code.

**Part 4/6 of the pre-1.0 improvements series.** Depends on #5.