### PR TITLE
docs: Fix documentation examples to match real API

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -168,7 +168,7 @@ pub type Receiver<T> = SplitStream<Transport<T>>;
 ///
 /// - `T`: The underlying I/O stream type (`AsyncRead + AsyncWrite`)
 /// - `I`: Metadata type for incoming requests (default: `()`)
-/// Outgoing requests always resolve to [`Response`].
+///   Outgoing requests always resolve to [`Response`].
 ///
 /// # Examples
 ///
@@ -488,7 +488,7 @@ where
             Message::Notification(notif) => {
                 if notif.method == crate::request_queue::CANCEL_REQUEST_METHOD {
                     if let Some(id) = crate::parse_cancel_params(&notif.params) {
-                        self.request_queue.incoming.cancel(&id);
+                        let _ = self.request_queue.incoming.cancel(&id);
                     }
                     crate::IncomingMessage::CancelHandled
                 } else {
@@ -748,9 +748,13 @@ where
     /// let mut conn: Connection<_, ()> = Connection::new(stream);
     ///
     /// let (id, params) = conn.initialize_start().await.unwrap();
-    /// // Process params, build capabilities...
+    /// // Process params, build the full InitializeResult payload...
     /// let capabilities = serde_json::json!({"textDocumentSync": 1});
-    /// conn.initialize_finish(id, capabilities).await.unwrap();
+    /// let result = serde_json::json!({
+    ///     "capabilities": capabilities,
+    ///     "serverInfo": {"name": "my-server", "version": "0.1.0"}
+    /// });
+    /// conn.initialize_finish(id, result).await.unwrap();
     /// # });
     /// ```
     pub async fn initialize_start(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,30 +9,65 @@
 //!
 //! ## Quick Start
 //!
-//! ```
-//! use lsp_server_tokio::{duplex_transport, Message, Request, Response};
-//! use futures::{SinkExt, StreamExt};
+//! ```no_run
+//! use futures::StreamExt;
+//! use lsp_server_tokio::{Connection, IncomingMessage, Response};
 //!
 //! # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
-//! // Create in-memory transport pair for testing
+//! let mut conn = Connection::stdio();
+//! let capabilities = serde_json::json!({
+//!     "documentFormattingProvider": true
+//! });
+//!
+//! let _client_params = conn.initialize(capabilities).await?;
+//! let sender = conn.client_sender().expect("client sender should be available");
+//!
+//! while let Some(result) = conn.receiver.next().await {
+//!     let msg = result?;
+//!
+//!     match conn.route(msg) {
+//!         IncomingMessage::Request(req, _) if req.method == "shutdown" => {
+//!             conn.handle_shutdown(req.id).await?;
+//!         }
+//!         IncomingMessage::Request(req, _) => {
+//!             sender.respond(Response::ok(req.id, serde_json::Value::Null))?;
+//!         }
+//!         IncomingMessage::Notification(notif) if notif.method == "exit" => {
+//!             break;
+//!         }
+//!         IncomingMessage::CancelHandled => {}
+//!         IncomingMessage::Notification(_) => {}
+//!         IncomingMessage::ResponseRouted | IncomingMessage::ResponseUnknown(_) => {}
+//!     }
+//! }
+//! # Ok::<(), Box<dyn std::error::Error>>(()) });
+//! ```
+//!
+//! ## Testing
+//!
+//! Use [`duplex_transport()`] when you want connected in-memory transports for unit
+//! and integration tests without stdio:
+//!
+//! ```
+//! use futures::{SinkExt, StreamExt};
+//! use lsp_server_tokio::{duplex_transport, Message, Request, Response};
+//!
+//! # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
 //! let (mut client, mut server) = duplex_transport(4096);
 //!
-//! // Send a request from client
-//! let request = Message::Request(Request::new(1, "textDocument/hover", None));
-//! client.send(request).await.unwrap();
+//! client
+//!     .send(Message::Request(Request::new(1, "textDocument/hover", None)))
+//!     .await
+//!     .unwrap();
 //!
-//! // Receive on server
 //! if let Some(Ok(Message::Request(req))) = server.next().await {
-//!     println!("Received: {}", req.method);
-//!
-//!     // Send response back
-//!     let response = Message::Response(Response::ok(1, serde_json::json!({"contents": "Hello"})));
-//!     server.send(response).await.unwrap();
-//! }
-//!
-//! // Receive response on client
-//! if let Some(Ok(Message::Response(resp))) = client.next().await {
-//!     println!("Got response for id: {:?}", resp.id);
+//!     server
+//!         .send(Message::Response(Response::ok(
+//!             req.id,
+//!             serde_json::json!({"contents": "Hello"}),
+//!         )))
+//!         .await
+//!         .unwrap();
 //! }
 //! # });
 //! ```


### PR DESCRIPTION
## Summary

Update all doc examples and module-level documentation to reflect the current API after the preceding refactors.

## Changes

- Fixed `Connection` doc examples (2 type params, not 3)
- Updated crate-level docs with correct initialization flow
- Ensured all `cargo test --doc` examples compile and pass

**Part 5/6 of the pre-1.0 improvements series.** Depends on #6.