### PR TITLE
feat: Message & routing ergonomics

### DIFF
--- a/examples/formatter_server.rs
+++ b/examples/formatter_server.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use futures::StreamExt;
 use lsp_server_tokio::{
     cancelled_response, method_not_found_response, ClientSender, Connection, IncomingMessage,
-    Notification, Response,
+    Notification, Response, EXIT_METHOD, SHUTDOWN_METHOD,
 };
 use lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
@@ -121,7 +121,7 @@ where
         match conn.route(msg) {
             IncomingMessage::Request(req, token) => {
                 // Handle shutdown specially
-                if req.method == "shutdown" {
+                if req.method == SHUTDOWN_METHOD {
                     conn.handle_shutdown(req.id).ok();
                     continue;
                 }
@@ -138,7 +138,7 @@ where
             }
             IncomingMessage::Notification(notif) => {
                 // Handle exit notification
-                if notif.method == "exit" {
+                if notif.method == EXIT_METHOD {
                     let exit_code = conn.handle_exit();
                     std::process::exit(exit_code as i32);
                 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -83,6 +83,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::client_sender::ResponseMap;
 use crate::lifecycle::{ExitCode, LifecycleState, ProtocolError};
+use crate::routing::{EXIT_METHOD, INITIALIZED_METHOD, INITIALIZE_METHOD};
 use crate::ClientSender;
 use crate::{transport, Message, RequestQueue, Transport};
 
@@ -756,7 +757,7 @@ where
         loop {
             match self.receiver.next().await {
                 Some(Ok(Message::Request(req))) => {
-                    if req.method == "initialize" {
+                    if req.method == INITIALIZE_METHOD {
                         self.lifecycle_state = LifecycleState::Initializing;
                         return Ok((req.id, req.params.unwrap_or(serde_json::Value::Null)));
                     }
@@ -773,7 +774,7 @@ where
                     // Continue waiting for initialize
                 }
                 Some(Ok(Message::Notification(notif))) => {
-                    if notif.method == "exit" {
+                    if notif.method == EXIT_METHOD {
                         return Err(ProtocolError::Disconnected);
                     }
                     // Drop other notifications silently
@@ -847,7 +848,7 @@ where
             loop {
                 match self.receiver.next().await {
                     Some(Ok(Message::Notification(notif))) => {
-                        if notif.method == "initialized" {
+                        if notif.method == INITIALIZED_METHOD {
                             self.lifecycle_state = LifecycleState::Running;
                             return Ok(());
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,10 @@ pub use request_id::RequestId;
 pub use request_queue::{
     parse_cancel_params, IncomingRequests, OutgoingRequests, RequestQueue, CANCEL_REQUEST_METHOD,
 };
-pub use routing::{cancelled_response, method_not_found_response, IncomingMessage};
+pub use routing::{
+    cancelled_response, method_not_found_response, IncomingMessage, EXIT_METHOD,
+    INITIALIZED_METHOD, INITIALIZE_METHOD, SHUTDOWN_METHOD,
+};
 pub use transport::{duplex_transport, transport, Transport};
 
 // Re-export CancellationToken for ergonomic use with IncomingMessage::Request

--- a/src/message.rs
+++ b/src/message.rs
@@ -476,6 +476,24 @@ pub enum Message {
     Notification(Notification),
 }
 
+impl From<Request> for Message {
+    fn from(req: Request) -> Self {
+        Message::Request(req)
+    }
+}
+
+impl From<Response> for Message {
+    fn from(resp: Response) -> Self {
+        Message::Response(resp)
+    }
+}
+
+impl From<Notification> for Message {
+    fn from(notif: Notification) -> Self {
+        Message::Notification(notif)
+    }
+}
+
 impl Message {
     /// Returns `true` if this is a Request message.
     #[must_use]
@@ -493,6 +511,60 @@ impl Message {
     #[must_use]
     pub fn is_notification(&self) -> bool {
         matches!(self, Message::Notification(_))
+    }
+
+    /// Returns a reference to the inner [`Request`], if this is a Request message.
+    #[must_use]
+    pub fn as_request(&self) -> Option<&Request> {
+        match self {
+            Message::Request(req) => Some(req),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the inner [`Response`], if this is a Response message.
+    #[must_use]
+    pub fn as_response(&self) -> Option<&Response> {
+        match self {
+            Message::Response(resp) => Some(resp),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the inner [`Notification`], if this is a Notification message.
+    #[must_use]
+    pub fn as_notification(&self) -> Option<&Notification> {
+        match self {
+            Message::Notification(notif) => Some(notif),
+            _ => None,
+        }
+    }
+
+    /// Consumes the message and returns the inner [`Request`], if this is a Request message.
+    #[must_use]
+    pub fn into_request(self) -> Option<Request> {
+        match self {
+            Message::Request(req) => Some(req),
+            _ => None,
+        }
+    }
+
+    /// Consumes the message and returns the inner [`Response`], if this is a Response message.
+    #[must_use]
+    pub fn into_response(self) -> Option<Response> {
+        match self {
+            Message::Response(resp) => Some(resp),
+            _ => None,
+        }
+    }
+
+    /// Consumes the message and returns the inner [`Notification`], if this is a Notification message.
+    #[must_use]
+    pub fn into_notification(self) -> Option<Notification> {
+        match self {
+            Message::Notification(notif) => Some(notif),
+            _ => None,
+        }
     }
 }
 
@@ -922,5 +994,90 @@ mod tests {
         let resp: Response = serde_json::from_str(json).unwrap();
         assert!(resp.result().is_some());
         assert!(resp.result().unwrap().is_null());
+    }
+
+    // ============== From Impls Tests ==============
+
+    #[test]
+    fn from_request_for_message() {
+        let req = Request::new(1, "test", None);
+        let msg: Message = req.into();
+        assert!(msg.is_request());
+    }
+
+    #[test]
+    fn from_response_for_message() {
+        let resp = Response::ok(1, json!(null));
+        let msg: Message = resp.into();
+        assert!(msg.is_response());
+    }
+
+    #[test]
+    fn from_notification_for_message() {
+        let notif = Notification::new("test", None);
+        let msg: Message = notif.into();
+        assert!(msg.is_notification());
+    }
+
+    // ============== Message Accessor Tests ==============
+
+    #[test]
+    fn message_as_request() {
+        let msg = Message::Request(Request::new(1, "test", None));
+        assert!(msg.as_request().is_some());
+        assert_eq!(msg.as_request().unwrap().method, "test");
+        assert!(msg.as_response().is_none());
+        assert!(msg.as_notification().is_none());
+    }
+
+    #[test]
+    fn message_as_response() {
+        let msg = Message::Response(Response::ok(1, json!(null)));
+        assert!(msg.as_response().is_some());
+        assert!(msg.as_response().unwrap().is_ok());
+        assert!(msg.as_request().is_none());
+        assert!(msg.as_notification().is_none());
+    }
+
+    #[test]
+    fn message_as_notification() {
+        let msg = Message::Notification(Notification::new("test", None));
+        assert!(msg.as_notification().is_some());
+        assert_eq!(msg.as_notification().unwrap().method, "test");
+        assert!(msg.as_request().is_none());
+        assert!(msg.as_response().is_none());
+    }
+
+    #[test]
+    fn message_into_request() {
+        let msg = Message::Request(Request::new(1, "test", None));
+        let req = msg.into_request().unwrap();
+        assert_eq!(req.method, "test");
+    }
+
+    #[test]
+    fn message_into_response() {
+        let msg = Message::Response(Response::ok(1, json!(null)));
+        let resp = msg.into_response().unwrap();
+        assert!(resp.is_ok());
+    }
+
+    #[test]
+    fn message_into_notification() {
+        let msg = Message::Notification(Notification::new("test", None));
+        let notif = msg.into_notification().unwrap();
+        assert_eq!(notif.method, "test");
+    }
+
+    #[test]
+    fn message_into_wrong_variant_returns_none() {
+        let msg = Message::Request(Request::new(1, "test", None));
+        assert!(msg.into_response().is_none());
+
+        let msg = Message::Response(Response::ok(1, json!(null)));
+        assert!(msg.into_notification().is_none());
+
+        let msg = Message::Notification(Notification::new("test", None));
+        assert!(msg.into_request().is_none());
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -32,6 +32,18 @@ use tokio_util::sync::CancellationToken;
 use crate::error::{ErrorCode, ResponseError};
 use crate::message::{Notification, Request, Response};
 
+/// The method name for the `initialize` request.
+pub const INITIALIZE_METHOD: &str = "initialize";
+
+/// The method name for the `initialized` notification.
+pub const INITIALIZED_METHOD: &str = "initialized";
+
+/// The method name for the `shutdown` request.
+pub const SHUTDOWN_METHOD: &str = "shutdown";
+
+/// The method name for the `exit` notification.
+pub const EXIT_METHOD: &str = "exit";
+
 /// Represents a classified incoming message after routing.
 ///
 /// When a [`Message`](crate::Message) is received from the transport, it is classified


### PR DESCRIPTION
## Summary
- Export well-known LSP method name constants (`INITIALIZE_METHOD`, `INITIALIZED_METHOD`, `SHUTDOWN_METHOD`, `EXIT_METHOD`) to prevent typos in string literals
- Add `From<Request/Response/Notification>` for `Message` enabling `.into()` conversions
- Add `Message` accessor methods (`as_request`, `as_response`, `as_notification`, `into_request`, `into_response`, `into_notification`)
- Update internal usages in `connection.rs` and the example to use method constants

## Test plan
- [x] All existing tests pass
- [x] New tests for `From` impls and `Message` accessor methods
- [x] `cargo clippy --pedantic` clean
- [x] `cargo fmt --check` clean
- [x] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Part 1 of 4 in the pre-1.0 ergonomics stack. PRs 2-4 build on this.