### PR TITLE
feat: Testing infrastructure & codec hardening

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -41,6 +41,9 @@ use crate::Message;
 /// The header terminator sequence for LSP wire protocol (CRLF CRLF).
 const HEADER_TERMINATOR: &[u8] = b"\r\n\r\n";
 
+/// The default maximum Content-Length value (10 MB).
+const DEFAULT_MAX_CONTENT_LENGTH: usize = 10 * 1024 * 1024;
+
 /// LSP wire protocol codec implementing Content-Length framing.
 ///
 /// This codec handles encoding and decoding of LSP [`Message`] types using
@@ -60,24 +63,49 @@ const HEADER_TERMINATOR: &[u8] = b"\r\n\r\n";
 /// - Returns `Ok(None)` if the body is incomplete
 /// - Returns `Ok(Some(message))` when a complete message is available
 ///
+/// A maximum Content-Length guard (default 10 MB) prevents memory exhaustion
+/// from malformed or malicious input.
+///
 /// # Thread Safety
 ///
 /// `LspCodec` maintains internal parsing state and should not be shared between
 /// concurrent readers. Use one codec instance per direction (read/write) or
 /// use `Framed` which handles this correctly.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LspCodec {
     /// The content length parsed from headers, None if still reading headers.
     content_length: Option<usize>,
+    /// Maximum allowed Content-Length value.
+    max_content_length: usize,
 }
 
 impl LspCodec {
-    /// Creates a new `LspCodec` ready to encode and decode messages.
+    /// Creates a new `LspCodec` with the default max content length (10 MB).
     #[must_use]
     pub fn new() -> Self {
         Self {
             content_length: None,
+            max_content_length: DEFAULT_MAX_CONTENT_LENGTH,
         }
+    }
+
+    /// Creates a new `LspCodec` with a custom max content length.
+    ///
+    /// # Arguments
+    ///
+    /// * `max` - Maximum allowed Content-Length in bytes
+    #[must_use]
+    pub fn with_max_content_length(max: usize) -> Self {
+        Self {
+            content_length: None,
+            max_content_length: max,
+        }
+    }
+}
+
+impl Default for LspCodec {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -96,6 +124,17 @@ impl Decoder for LspCodec {
             // Parse Content-Length from headers
             let headers = &src[..header_end];
             let content_length = parse_content_length(headers)?;
+
+            // Reject messages that exceed the maximum allowed size
+            if content_length > self.max_content_length {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Content-Length {content_length} exceeds maximum {}",
+                        self.max_content_length
+                    ),
+                ));
+            }
 
             // Remove headers from buffer (including terminator)
             src.advance(header_end + HEADER_TERMINATOR.len());
@@ -499,5 +538,62 @@ mod tests {
 
         let result = codec.decode(&mut buf);
         assert!(result.is_err());
+    }
+
+    // ============== Content-Length Guard Tests ==============
+
+    #[test]
+    fn decode_at_max_limit_passes() {
+        let json_body = r#"{"jsonrpc":"2.0","id":1,"method":"test"}"#;
+        // Set max to exactly the body size
+        let mut codec = LspCodec::with_max_content_length(json_body.len());
+        let mut buf = BytesMut::new();
+
+        let framed = format!("Content-Length: {}\r\n\r\n{}", json_body.len(), json_body);
+        buf.extend_from_slice(framed.as_bytes());
+
+        let msg = codec.decode(&mut buf).unwrap().unwrap();
+        assert!(msg.is_request());
+    }
+
+    #[test]
+    fn decode_over_max_limit_rejected() {
+        let json_body = r#"{"jsonrpc":"2.0","id":1,"method":"test"}"#;
+        // Set max to one less than body size
+        let mut codec = LspCodec::with_max_content_length(json_body.len() - 1);
+        let mut buf = BytesMut::new();
+
+        let framed = format!("Content-Length: {}\r\n\r\n{}", json_body.len(), json_body);
+        buf.extend_from_slice(framed.as_bytes());
+
+        let result = codec.decode(&mut buf);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn decode_custom_limit_works() {
+        // Very small custom limit
+        let mut codec = LspCodec::with_max_content_length(10);
+        let mut buf = BytesMut::new();
+
+        let json_body = r#"{"jsonrpc":"2.0","id":1,"method":"test"}"#;
+        let framed = format!("Content-Length: {}\r\n\r\n{}", json_body.len(), json_body);
+        buf.extend_from_slice(framed.as_bytes());
+
+        let result = codec.decode(&mut buf);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn default_max_content_length_is_10mb() {
+        let codec = LspCodec::new();
+        assert_eq!(codec.max_content_length, 10 * 1024 * 1024);
+
+        let codec_default = LspCodec::default();
+        assert_eq!(codec_default.max_content_length, 10 * 1024 * 1024);
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -77,7 +77,7 @@ use std::task::{Context, Poll};
 use futures::stream::SplitStream;
 use futures::{SinkExt, StreamExt};
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, Stdin, Stdout};
+use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadBuf, Stdin, Stdout};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -1231,6 +1231,38 @@ impl Connection<StdioTransport> {
     }
 }
 
+impl Connection<DuplexStream> {
+    /// Creates a pair of connected in-memory connections for testing.
+    ///
+    /// Messages sent on one connection are received by the other.
+    /// Both connections have independent request queues, lifecycle state,
+    /// and [`ClientSender`] handles.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer_size` - Size of the internal buffer in bytes (1024-8192 recommended)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use futures::StreamExt;
+    /// use lsp_server_tokio::{Connection, Message, Request};
+    ///
+    /// # tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap().block_on(async {
+    /// let (mut client, mut server) = Connection::pair(4096);
+    ///
+    /// client.send(Request::new(1, "test", None).into()).unwrap();
+    /// let msg = server.receiver.next().await.unwrap().unwrap();
+    /// assert!(msg.is_request());
+    /// # });
+    /// ```
+    #[must_use]
+    pub fn pair(buffer_size: usize) -> (Self, Self) {
+        let (a, b) = tokio::io::duplex(buffer_size);
+        (Connection::new(a), Connection::new(b))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1433,6 +1465,31 @@ mod tests {
             response.result().cloned(),
             Some(serde_json::json!("response data"))
         );
+    }
+
+    #[tokio::test]
+    async fn connection_pair_test() {
+        let (mut client, mut server) = Connection::pair(4096);
+
+        // Send request from client to server
+        client
+            .send(Request::new(1, "textDocument/hover", None).into())
+            .unwrap();
+
+        let msg = server.receiver.next().await.unwrap().unwrap();
+        assert!(msg.is_request());
+        let req = msg.into_request().unwrap();
+        assert_eq!(req.method, "textDocument/hover");
+
+        // Send response back
+        server
+            .send(Response::ok(req.id, json!({"contents": "hello"})).into())
+            .unwrap();
+
+        let msg = client.receiver.next().await.unwrap().unwrap();
+        assert!(msg.is_response());
+        let resp = msg.into_response().unwrap();
+        assert!(resp.is_ok());
     }
 
     // Note: Connection::stdio() cannot be tested in unit tests as it requires


### PR DESCRIPTION
## Summary
- Add `Connection::pair(buffer_size)` for creating connected in-memory connection pairs for testing — the most impactful testing improvement
- Add configurable Content-Length max guard to `LspCodec` (default 10 MB) to prevent memory exhaustion from malformed/malicious input
- Add `LspCodec::with_max_content_length()` constructor for custom limits

## Test plan
- [x] Test for `Connection::pair()` with request/response flow
- [x] Tests for Content-Length guard: at-limit passes, over-limit rejected, custom limit works, default is 10MB
- [x] `cargo clippy --pedantic` clean
- [x] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Part 4 of 4 in the pre-1.0 ergonomics stack. Stacked on PR #20.